### PR TITLE
⚡ Speedup `Stream.read` by 83% by using collections.abc.Mapping instead of typing.Mapping [codeflash]

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/core.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/core.py
@@ -6,9 +6,12 @@ import inspect
 import itertools
 import logging
 from abc import ABC, abstractmethod
+from collections.abc import Mapping as MappingABC
 from dataclasses import dataclass
 from functools import cached_property, lru_cache
 from typing import Any, Dict, Iterable, Iterator, List, Mapping, MutableMapping, Optional, Union
+
+from deprecated import deprecated
 
 import airbyte_cdk.sources.utils.casing as casing
 from airbyte_cdk.models import AirbyteMessage, AirbyteStream, ConfiguredAirbyteStream, DestinationSyncMode, SyncMode
@@ -24,12 +27,10 @@ from airbyte_cdk.sources.streams.checkpoint import (
     ResumableFullRefreshCheckpointReader,
 )
 from airbyte_cdk.sources.types import StreamSlice
-
 # list of all possible HTTP methods which can be used for sending of request bodies
 from airbyte_cdk.sources.utils.schema_helpers import InternalConfig, ResourceSchemaLoader
 from airbyte_cdk.sources.utils.slice_logger import DebugSliceLogger, SliceLogger
 from airbyte_cdk.sources.utils.transform import TransformConfig, TypeTransformer
-from deprecated import deprecated
 
 # A stream's read method can return one of the following types:
 # Mapping[str, Any]: The content of an AirbyteRecordMessage
@@ -191,10 +192,10 @@ class Stream(ABC):
             )
             for record_data_or_message in records:
                 yield record_data_or_message
-                if isinstance(record_data_or_message, Mapping) or (
+                if isinstance(record_data_or_message, MappingABC) or (
                     hasattr(record_data_or_message, "type") and record_data_or_message.type == MessageType.RECORD
                 ):
-                    record_data = record_data_or_message if isinstance(record_data_or_message, Mapping) else record_data_or_message.record
+                    record_data = record_data_or_message if isinstance(record_data_or_message, MappingABC) else record_data_or_message.record
 
                     # Thanks I hate it. RFR fundamentally doesn't fit with the concept of the legacy Stream.get_updated_state()
                     # method because RFR streams rely on pagination as a cursor. Stream.get_updated_state() was designed to make


### PR DESCRIPTION
📈 Performance improved by 83% (0.83x faster)

⏱️ Runtime went down from 1.449 seconds to 0.793 seconds

For the main read loop, the instance check was a heavy operation.
It had a timing behavior like the following where the typing instance checks took a really long time
```
├─ 1.449 Customers.read  airbyte_cdk/sources/streams/core.py:153
│  ├─ 0.811 _SpecialGenericAlias.__instancecheck__  typing.py:1327
│  │     [4 frames hidden]  typing, <frozen abc>
│  └─ 0.436 [self]  airbyte_cdk/sources/streams/core.py
```

With the optimized version, this is the resulting timing info
```
├─ 0.793 Customers.read  airbyte_cdk/sources/streams/core.py:154
│  ├─ 0.466 [self]  airbyte_cdk/sources/streams/core.py
│  └─ 0.161 Mapping.__instancecheck__  <frozen abc>:117
```
typing.Mapping is deprecated and collections.abc.Mapping is the preferred alternative. It also has much faster performance.  typing.Mapping internally uses collections.abc.Mapping but has overhead. 